### PR TITLE
Add IQA training utilities with sampling, losses and evaluation

### DIFF
--- a/computer_vision/iqa/common/eval.py
+++ b/computer_vision/iqa/common/eval.py
@@ -1,0 +1,57 @@
+import torch
+
+
+def pearsonr(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    x = x.view(-1).double()
+    y = y.view(-1).double()
+    vx = x - x.mean()
+    vy = y - y.mean()
+    return (vx * vy).sum() / (torch.sqrt((vx ** 2).sum()) * torch.sqrt((vy ** 2).sum()) + 1e-8)
+
+
+def logistic4(x: torch.Tensor, beta: torch.Tensor) -> torch.Tensor:
+    b1, b2, b3, b4 = beta
+    return b1 + (b2 - b1) / (1.0 + torch.exp(-b3 * (x - b4)))
+
+
+def logistic5(x: torch.Tensor, beta: torch.Tensor) -> torch.Tensor:
+    b1, b2, b3, b4, b5 = beta
+    return b1 + (b2 - b1) / (1.0 + torch.exp(-b3 * (x - b4))) ** b5
+
+
+def fit_logistic(x: torch.Tensor, y: torch.Tensor, kind: str = "5", max_iter: int = 500) -> torch.Tensor:
+    x = x.view(-1).double()
+    y = y.view(-1).double()
+    if kind == "4":
+        beta = torch.nn.Parameter(torch.tensor([y.min(), y.max(), 1.0, x.mean()], dtype=torch.double))
+        func = logistic4
+    else:
+        beta = torch.nn.Parameter(torch.tensor([y.min(), y.max(), 1.0, x.mean(), 1.0], dtype=torch.double))
+        func = logistic5
+
+    optimizer = torch.optim.LBFGS([beta], max_iter=max_iter)
+
+    def closure():
+        optimizer.zero_grad()
+        pred = func(x, beta)
+        loss = torch.mean((pred - y) ** 2)
+        loss.backward()
+        return loss
+
+    optimizer.step(closure)
+    return beta.detach()
+
+
+def logistic_fit_metrics(pred: torch.Tensor, target: torch.Tensor, kind: str = "5"):
+    """Fit logistic curve then compute PLCC, RMSE and GoF."""
+    pred = pred.view(-1).double()
+    target = target.view(-1).double()
+    beta = fit_logistic(pred, target, kind)
+    func = logistic4 if kind == "4" else logistic5
+    mapped = func(pred, beta)
+    plcc = pearsonr(mapped, target)
+    rmse = torch.sqrt(torch.mean((mapped - target) ** 2))
+    sse = torch.sum((mapped - target) ** 2)
+    sst = torch.sum((target - target.mean()) ** 2)
+    gof = 1 - sse / sst
+    return float(plcc), float(rmse), float(gof)

--- a/computer_vision/iqa/common/group_sampler.py
+++ b/computer_vision/iqa/common/group_sampler.py
@@ -1,0 +1,69 @@
+import random
+from collections import defaultdict
+from typing import List, Sequence
+
+from torch.utils.data import Sampler
+
+
+class GroupSampler(Sampler[int]):
+    """Group-balanced sampler with cross-scene parameter alignment.
+
+    Each sample in the dataset should have an associated ``scene`` and
+    ``param`` identifier.  The sampler groups samples by ``param`` and ensures
+    that indices from different scenes but with the same parameter value are
+    aligned.  During iteration it yields indices so that every parameter group
+    contributes the same number of samples from every scene.
+
+    Args:
+        scenes: sequence of scene identifiers for each sample in the dataset.
+        params: sequence of parameter identifiers for each sample.
+        shuffle: if ``True`` the aligned groups are shuffled before yielding.
+    """
+
+    def __init__(self, scenes: Sequence[int], params: Sequence[int], shuffle: bool = True) -> None:
+        assert len(scenes) == len(params), "scenes and params must be the same length"
+        self.scenes = list(scenes)
+        self.params = list(params)
+        self.shuffle = shuffle
+
+        # Build mapping: param -> scene -> [indices]
+        group_dict: dict = defaultdict(lambda: defaultdict(list))
+        for idx, (s, p) in enumerate(zip(self.scenes, self.params)):
+            group_dict[p][s].append(idx)
+
+        self.scene_ids: List[int] = sorted(set(self.scenes))
+
+        # Ensure cross-scene alignment by constructing packets of indices
+        param_packets = {}
+        for p, scene_map in group_dict.items():
+            # Skip parameter groups that do not contain all scenes
+            if any(s not in scene_map for s in self.scene_ids):
+                continue
+            # Sort indices in each scene for deterministic behaviour
+            for indices in scene_map.values():
+                indices.sort()
+            min_len = min(len(scene_map[s]) for s in self.scene_ids)
+            packets = [[scene_map[s][i] for s in self.scene_ids] for i in range(min_len)]
+            param_packets[p] = packets
+
+        # Balance the number of packets across all parameters
+        if param_packets:
+            min_packets = min(len(v) for v in param_packets.values())
+        else:
+            min_packets = 0
+        packets: List[List[int]] = []
+        for p, p_packets in param_packets.items():
+            packets.extend(p_packets[:min_packets])
+
+        self.packets = packets
+
+    def __iter__(self):
+        packets = list(self.packets)
+        if self.shuffle:
+            random.shuffle(packets)
+        for packet in packets:
+            for idx in packet:
+                yield idx
+
+    def __len__(self) -> int:  # number of indices this sampler will provide
+        return len(self.packets) * len(self.scene_ids)

--- a/computer_vision/iqa/common/losses.py
+++ b/computer_vision/iqa/common/losses.py
@@ -1,0 +1,44 @@
+import torch
+import torch.nn.functional as F
+
+
+def plcc_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """1 - Pearson Linear Correlation Coefficient."""
+    pred = pred.view(-1)
+    target = target.view(-1)
+    vx = pred - pred.mean()
+    vy = target - target.mean()
+    plcc = (vx * vy).sum() / (torch.sqrt((vx ** 2).sum()) * torch.sqrt((vy ** 2).sum()) + 1e-8)
+    return 1 - plcc
+
+
+def l1_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    return F.l1_loss(pred, target)
+
+
+def listwise_rank_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Listwise pairwise ranking loss using logistic formulation."""
+    pred = pred.view(-1)
+    target = target.view(-1)
+    diff_pred = pred.unsqueeze(1) - pred.unsqueeze(0)
+    diff_target = target.unsqueeze(1) - target.unsqueeze(0)
+    mask = diff_target > 0
+    if mask.any():
+        loss = F.binary_cross_entropy_with_logits(diff_pred[mask], torch.ones_like(diff_pred[mask]))
+    else:
+        loss = torch.tensor(0.0, device=pred.device)
+    return loss
+
+
+def l_delta(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """L1 loss on pairwise score differences."""
+    pred = pred.view(-1)
+    target = target.view(-1)
+    diff_pred = pred.unsqueeze(1) - pred.unsqueeze(0)
+    diff_target = target.unsqueeze(1) - target.unsqueeze(0)
+    return torch.mean(torch.abs(diff_pred - diff_target))
+
+
+def iqa_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Combined IQA training loss."""
+    return plcc_loss(pred, target) + l1_loss(pred, target) + listwise_rank_loss(pred, target) + l_delta(pred, target)

--- a/computer_vision/iqa/train_template.py
+++ b/computer_vision/iqa/train_template.py
@@ -1,0 +1,70 @@
+"""Generic training and validation template for IQA models."""
+from typing import Tuple
+
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from common.group_sampler import GroupSampler
+from common.losses import iqa_loss
+from common.eval import logistic_fit_metrics
+
+
+class DummyDataset(Dataset):
+    """A minimal dataset example.
+
+    Args:
+        data: image tensors.
+        labels: quality scores.
+        scenes: scene identifiers for each sample.
+        params: parameter identifiers for each sample.
+    """
+
+    def __init__(self, data: torch.Tensor, labels: torch.Tensor, scenes, params):
+        self.data = data
+        self.labels = labels
+        self.scenes = scenes
+        self.params = params
+
+    def __len__(self) -> int:  # type: ignore[override]
+        return len(self.data)
+
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:  # type: ignore[override]
+        return self.data[idx], self.labels[idx]
+
+
+def train_template(model: torch.nn.Module, train_ds: Dataset, val_ds: Dataset,
+                   epochs: int = 1, batch_size: int = 8, lr: float = 1e-4):
+    """Train ``model`` using provided datasets and evaluate each epoch."""
+    sampler = GroupSampler(train_ds.scenes, train_ds.params, shuffle=True)
+    train_loader = DataLoader(train_ds, batch_size=batch_size, sampler=sampler)
+    val_loader = DataLoader(val_ds, batch_size=batch_size, shuffle=False)
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+
+    for epoch in range(epochs):
+        model.train()
+        for imgs, labels in train_loader:
+            preds = model(imgs).squeeze()
+            loss = iqa_loss(preds, labels.float())
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+        # validation
+        model.eval()
+        preds_all, labels_all = [], []
+        with torch.no_grad():
+            for imgs, labels in val_loader:
+                preds = model(imgs).squeeze()
+                preds_all.append(preds)
+                labels_all.append(labels.float())
+        preds_cat = torch.cat(preds_all)
+        labels_cat = torch.cat(labels_all)
+        plcc, rmse, gof = logistic_fit_metrics(preds_cat, labels_cat)
+        print(f"Epoch {epoch + 1}: PLCC={plcc:.4f} RMSE={rmse:.4f} GoF={gof:.4f}")
+
+
+__all__ = [
+    "DummyDataset",
+    "train_template",
+]


### PR DESCRIPTION
## Summary
- add group-balanced sampler that aligns parameter groups across scenes
- implement combined IQA loss: 1-PLCC + L1 + listwise rank loss + L_delta
- provide logistic-fit PLCC/RMSE/GoF evaluation and training template

## Testing
- `python -m py_compile computer_vision/iqa/common/group_sampler.py computer_vision/iqa/common/losses.py computer_vision/iqa/common/eval.py computer_vision/iqa/train_template.py`
- `python - <<'PY'
import torch
from computer_vision.iqa.train_template import DummyDataset, train_template
from torch import nn
class DummyModel(nn.Module):
    def __init__(self):
        super().__init__()
        self.linear = nn.Linear(10, 1)
    def forward(self, x):
        return self.linear(x)
PY` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch==2.0.1` *(fails: Could not find a version that satisfies the requirement torch==2.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_689a3347665c832e882ecb6b564e9c37