### PR TITLE
feat: add geometric order embedding and ranking network

### DIFF
--- a/computer_vision/iqa/geometric_order/__init__.py
+++ b/computer_vision/iqa/geometric_order/__init__.py
@@ -1,0 +1,17 @@
+"""Geometric order embedding and ranking network utilities."""
+
+from .order_embedding import geometric_order_embedding
+from .rank_network import (
+    RankNetwork,
+    listwise_ranking_loss,
+    plcc_loss,
+    combined_loss,
+)
+
+__all__ = [
+    "geometric_order_embedding",
+    "RankNetwork",
+    "listwise_ranking_loss",
+    "plcc_loss",
+    "combined_loss",
+]

--- a/computer_vision/iqa/geometric_order/order_embedding.py
+++ b/computer_vision/iqa/geometric_order/order_embedding.py
@@ -1,0 +1,55 @@
+"""Utility to generate geometric order embeddings for image quality lists.
+
+This module produces simple geometric order embeddings given lists of
+reference and distorted image quality scores.  The embeddings capture
+relative relationships such as differences and ratios, which are useful for
+list-wise ranking approaches in image quality assessment.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+import numpy as np
+
+
+def geometric_order_embedding(
+    reference: Iterable[float],
+    distorted: Iterable[float],
+    eps: float = 1e-8,
+) -> np.ndarray:
+    """Generate geometric order embeddings.
+
+    Parameters
+    ----------
+    reference: Iterable[float]
+        Quality scores for the pristine reference images.
+    distorted: Iterable[float]
+        Quality scores for the distorted images.  Must have the same length
+        as ``reference``.
+    eps: float, optional
+        Small value used to avoid division by zero.
+
+    Returns
+    -------
+    numpy.ndarray
+        An array of shape ``(N, 3)`` where ``N`` is the number of image
+        pairs.  For each pair the embedding contains three components:
+        ``difference`` (distorted - reference), ``ratio`` (distorted / reference)
+        and ``log_ratio`` (log(distorted) - log(reference)).
+
+    Notes
+    -----
+    The embedding is a compact representation of the geometric order between
+    two lists and can be fed into learning-to-rank models.
+    """
+    ref = np.asarray(list(reference), dtype=np.float32)
+    dis = np.asarray(list(distorted), dtype=np.float32)
+    if ref.shape != dis.shape:
+        raise ValueError("`reference` and `distorted` must have the same shape")
+    # Difference captures additive deviations
+    difference = dis - ref
+    # Ratio captures multiplicative deviations
+    ratio = dis / (ref + eps)
+    # Log-ratio provides a symmetric measure robust to scale
+    log_ratio = np.log(dis + eps) - np.log(ref + eps)
+    embedding = np.stack([difference, ratio, log_ratio], axis=-1)
+    return embedding

--- a/computer_vision/iqa/geometric_order/rank_network.py
+++ b/computer_vision/iqa/geometric_order/rank_network.py
@@ -1,0 +1,81 @@
+"""List-wise ranking network for image quality assessment.
+
+The module defines a small neural network that learns to order images by
+quality using a list-wise ranking objective.  In addition to predicting a
+relative ranking score for each item, the network also outputs a MOS
+(mean-opinion score) regression estimate.  The regression branch is trained
+with a ``1 - PLCC`` loss encouraging high correlation with ground-truth MOS
+values.
+"""
+from __future__ import annotations
+
+from typing import Tuple
+
+try:  # PyTorch is optional at import time.
+    import torch
+    from torch import nn
+except Exception:  # pragma: no cover - dependency missing
+    torch = None
+    nn = object  # type: ignore
+
+
+class RankNetwork(nn.Module):
+    """Simple feed-forward network with ranking and MOS heads."""
+
+    def __init__(self, in_dim: int, hidden_dim: int = 128) -> None:
+        if torch is None:  # pragma: no cover - defensive
+            raise ImportError("PyTorch is required to use RankNetwork")
+        super().__init__()
+        self.backbone = nn.Sequential(
+            nn.Linear(in_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+        )
+        # Ranking head outputs a score per item
+        self.rank_head = nn.Linear(hidden_dim, 1)
+        # MOS regression head
+        self.mos_head = nn.Linear(hidden_dim, 1)
+
+    def forward(self, x: "torch.Tensor") -> Tuple["torch.Tensor", "torch.Tensor"]:
+        """Return ranking scores and MOS estimates for the input list."""
+        feat = self.backbone(x)
+        rank_scores = self.rank_head(feat).squeeze(-1)
+        mos = self.mos_head(feat).squeeze(-1)
+        return rank_scores, mos
+
+
+def listwise_ranking_loss(
+    pred_scores: "torch.Tensor", target_scores: "torch.Tensor"
+) -> "torch.Tensor":
+    """ListNet-style cross entropy ranking loss."""
+    pred_prob = torch.softmax(pred_scores, dim=-1)
+    target_prob = torch.softmax(target_scores, dim=-1)
+    loss = -(target_prob * torch.log(pred_prob + 1e-12)).sum(dim=-1)
+    return loss.mean()
+
+
+def plcc_loss(
+    pred_mos: "torch.Tensor", target_mos: "torch.Tensor", eps: float = 1e-8
+) -> "torch.Tensor":
+    """Loss based on ``1 -`` Pearson Linear Correlation Coefficient."""
+    pred_mean = pred_mos.mean()
+    target_mean = target_mos.mean()
+    numerator = ((pred_mos - pred_mean) * (target_mos - target_mean)).mean()
+    denom = pred_mos.std() * target_mos.std() + eps
+    plcc = numerator / denom
+    return 1 - plcc
+
+
+def combined_loss(
+    pred_scores: "torch.Tensor",
+    target_scores: "torch.Tensor",
+    pred_mos: "torch.Tensor",
+    target_mos: "torch.Tensor",
+    alpha: float = 1.0,
+    beta: float = 1.0,
+) -> "torch.Tensor":
+    """Combined ranking and MOS regression loss."""
+    return alpha * listwise_ranking_loss(pred_scores, target_scores) + beta * plcc_loss(
+        pred_mos, target_mos
+    )


### PR DESCRIPTION
## Summary
- implement geometric order embedding for reference and distorted score lists
- add list-wise ranking network with MOS regression head and PLCC-based loss
- expose new IQA utilities via package init

## Testing
- `python -m pytest` *(fails: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_689a33575a24832e8ef98b9078a70fd8