### PR TITLE
Add multi-view MOS prediction modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/computer_vision/multi_view_iqa/README.md
+++ b/computer_vision/multi_view_iqa/README.md
@@ -1,0 +1,38 @@
+# Multi-view MOS Prediction
+
+This folder contains a lightweight implementation of a multi-view
+stereoscopic image quality assessment (IQA) model.  The code follows the
+architecture proposed in recent IQA literature, combining a **Distortion
+Feature Encoder (DFE)** with a **Multi-view Interaction Aggregation (MIA)**
+transformer to predict Mean Opinion Score (MOS) values for six input
+views.
+
+The implementation is intentionally compact to serve as a starting point
+for further research.
+
+## Components
+
+* `model.py` – definition of `DFEModule`, `MIAModule` and the combined
+  `MultiViewIQAModel`.
+* `dataset.py` – `MVSDataset` for loading six-view images and optional
+  depth maps from a metadata file.
+* `losses.py` – a collection of loss functions described in the design
+  document (Smooth L1, ranking, z-score MSE and anchor-based losses).
+* `utils.py` – helper utilities including a five-parameter logistic
+  mapping used during evaluation.
+* `train.py` – minimal example training loop.
+
+Each file contains extensive docstrings explaining the input/output
+shapes of the involved tensors.
+
+## Usage
+
+Prepare a metadata text file where each line contains the six image
+paths, optional six depth map paths and the MOS value.  Then run:
+
+```bash
+python -m computer_vision.multi_view_iqa.train path/to/meta.txt
+```
+
+The training script is deliberately minimal and intended for small scale
+experiments or as a template to build upon.

--- a/computer_vision/multi_view_iqa/__init__.py
+++ b/computer_vision/multi_view_iqa/__init__.py
@@ -1,0 +1,34 @@
+"""Multi-view stereoscopic MOS prediction package.
+
+This subpackage implements the core components described in the
+multi-view MOS prediction system:
+
+- :class:`DFEModule` for distortion feature extraction
+- :class:`MIAModule` for multi-view interaction aggregation
+- :class:`MultiViewIQAModel` combining the two modules
+
+The code is designed to be self contained so that users can easily
+plug it into their own training or evaluation pipelines.
+"""
+
+from .model import DFEModule, MIAModule, MultiViewIQAModel
+from .dataset import MVSDataset
+from .losses import (
+    smooth_l1,
+    pairwise_rank_loss,
+    zscore_mse,
+    anchor_consistency_loss,
+    anchor_relative_loss,
+)
+
+__all__ = [
+    "DFEModule",
+    "MIAModule",
+    "MultiViewIQAModel",
+    "MVSDataset",
+    "smooth_l1",
+    "pairwise_rank_loss",
+    "zscore_mse",
+    "anchor_consistency_loss",
+    "anchor_relative_loss",
+]

--- a/computer_vision/multi_view_iqa/dataset.py
+++ b/computer_vision/multi_view_iqa/dataset.py
@@ -1,0 +1,108 @@
+"""Dataset utilities for multi-view MOS prediction.
+
+This file provides a :class:`MVSDataset` class that reads six images and
+optionally six depth maps per sample.  The dataset expects a metadata
+file in which each line contains paths to the images, optional depth
+maps and the MOS score.  An example line is::
+
+    l1.png r1.png l2.png r2.png l3.png r3.png dl1.png dr1.png ... dr3.png 75.0
+
+If depth maps are not available the corresponding paths can be replaced
+by ``-``.  Additional columns after the MOS value are ignored.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Optional, Sequence
+
+import numpy as np
+from PIL import Image
+import torch
+from torch.utils.data import Dataset
+
+__all__ = ["MVSDataset", "load_image"]
+
+
+@dataclass
+class MVSSample:
+    images: List[Path]
+    depths: List[Optional[Path]]
+    mos: float
+    distortion_type: Optional[int] = None
+
+
+def load_image(path: Path) -> torch.Tensor:
+    """Read an image file into a ``torch.Tensor`` in the range [0, 1]."""
+    img = Image.open(path).convert("RGB")
+    return torch.from_numpy(np.array(img)).permute(2, 0, 1).float() / 255.0
+
+
+class MVSDataset(Dataset):
+    """Dataset for multi-view stereoscopic quality assessment.
+
+    Parameters
+    ----------
+    meta_file: str or Path
+        Path to the text file containing the metadata.
+    transform: callable, optional
+        Transform applied to each loaded image.
+    use_depth: bool, default=False
+        Whether depth maps are present in the metadata.
+    """
+
+    def __init__(
+        self,
+        meta_file: Path | str,
+        transform: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
+        use_depth: bool = False,
+    ) -> None:
+        self.meta_file = Path(meta_file)
+        self.transform = transform
+        self.use_depth = use_depth
+        self.samples: List[MVSSample] = []
+
+        with self.meta_file.open("r") as f:
+            for line in f:
+                parts = line.strip().split()
+                if self.use_depth:
+                    if len(parts) < 13:
+                        raise ValueError("Metadata line must contain 13+ columns with depth")
+                    img_paths = [Path(p) for p in parts[:6]]
+                    depth_paths = [None if p == "-" else Path(p) for p in parts[6:12]]
+                    mos = float(parts[12])
+                    dist_type = int(parts[13]) if len(parts) > 13 else None
+                else:
+                    if len(parts) < 7:
+                        raise ValueError("Metadata line must contain 7+ columns without depth")
+                    img_paths = [Path(p) for p in parts[:6]]
+                    depth_paths = [None] * 6
+                    mos = float(parts[6])
+                    dist_type = int(parts[7]) if len(parts) > 7 else None
+                self.samples.append(MVSSample(img_paths, depth_paths, mos, dist_type))
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.samples)
+
+    def __getitem__(self, idx: int):
+        sample = self.samples[idx]
+        imgs = []
+        deps = []
+        for ipath, dpath in zip(sample.images, sample.depths):
+            img = load_image(ipath)
+            if self.transform:
+                img = self.transform(img)
+            imgs.append(img)
+            if dpath is not None:
+                depth_img = Image.open(dpath).convert("L")
+                depth = torch.from_numpy(np.array(depth_img)).unsqueeze(0).float() / 255.0
+            else:
+                depth = torch.zeros(1, *img.shape[1:])
+            deps.append(depth)
+        return {
+            "images": imgs,
+            "depths": deps if self.use_depth else None,
+            "mos": torch.tensor([sample.mos], dtype=torch.float32),
+            "distortion_type": sample.distortion_type,
+        }

--- a/computer_vision/multi_view_iqa/losses.py
+++ b/computer_vision/multi_view_iqa/losses.py
@@ -1,0 +1,96 @@
+"""Loss functions for multi-view MOS prediction.
+
+This module collects the different loss components described in the
+specification.  They are implemented as lightweight PyTorch functions so
+that they can be composed in a training loop.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+import torch
+import torch.nn.functional as F
+
+__all__ = [
+    "smooth_l1",
+    "pairwise_rank_loss",
+    "zscore_mse",
+    "anchor_consistency_loss",
+    "anchor_relative_loss",
+]
+
+
+def smooth_l1(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Wrapper around :func:`torch.nn.functional.smooth_l1_loss`.
+
+    Parameters
+    ----------
+    pred, target: torch.Tensor
+        Predicted and ground truth MOS scores.
+    """
+
+    return F.smooth_l1_loss(pred, target)
+
+
+def pairwise_rank_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Simple pairwise ranking loss.
+
+    A hinge loss is applied to all pairs ``(i, j)`` where ``target[i] >
+    target[j]`` such that ``pred[i]`` should be greater than ``pred[j]``.
+    The implementation follows common practice in IQA literature.
+    """
+
+    N = pred.size(0)
+    if N < 2:
+        return pred.new_tensor(0.0)
+    loss = pred.new_tensor(0.0)
+    count = 0
+    for i in range(N):
+        for j in range(N):
+            if target[i] > target[j]:
+                loss = loss + F.relu(1.0 - (pred[i] - pred[j]))
+                count += 1
+    if count > 0:
+        loss = loss / count
+    return loss
+
+
+def zscore_mse(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Mean squared error computed on z-score normalised values."""
+
+    def _z(x: torch.Tensor) -> torch.Tensor:
+        return (x - x.mean()) / (x.std() + 1e-8)
+
+    return F.mse_loss(_z(pred), _z(target))
+
+
+def anchor_consistency_loss(
+    pred: torch.Tensor, target: torch.Tensor, max_val: float, min_val: float
+) -> torch.Tensor:
+    """Anchor consistency loss.
+
+    Parameters
+    ----------
+    pred, target: torch.Tensor
+        Batch predictions and ground truth scores.
+    max_val, min_val: float
+        Ground truth scores corresponding to the highest and lowest anchor
+        images respectively.
+    """
+
+    loss_max = F.mse_loss(pred.max(), pred.new_tensor(max_val))
+    loss_min = F.mse_loss(pred.min(), pred.new_tensor(min_val))
+    return loss_max + loss_min
+
+
+def anchor_relative_loss(
+    pred: torch.Tensor, target: torch.Tensor, max_val: float, min_val: float
+) -> torch.Tensor:
+    """Encourages relative distances to anchors to match the ground truth."""
+
+    anchor_max = pred.new_tensor(max_val)
+    anchor_min = pred.new_tensor(min_val)
+    diff_pred = torch.stack([anchor_max - pred, anchor_min - pred], dim=0)
+    diff_gt = torch.stack([anchor_max - target, anchor_min - target], dim=0)
+    return F.mse_loss(diff_pred, diff_gt)

--- a/computer_vision/multi_view_iqa/model.py
+++ b/computer_vision/multi_view_iqa/model.py
@@ -1,0 +1,197 @@
+"""Core model components for multi-view MOS prediction.
+
+This module implements the distortion feature encoder (DFE) and the
+multi-view interaction aggregation (MIA) transformer.  The design is
+inspired by the LoDa IQA model [Xu et al., CVPR 2024] and stereo image
+quality assessment research.
+
+The code is intentionally lightweight.  Only the high level logic is
+implemented; users can swap the backbone or extend the modules for
+research purposes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+try:  # optional import
+    from torchvision import models
+except Exception:  # pragma: no cover - torchvision is optional
+    models = None
+
+
+class DFEModule(nn.Module):
+    """Distortion Feature Encoding module.
+
+    Parameters
+    ----------
+    backbone: nn.Module
+        Convolutional backbone used to extract features.  If ``None`` a
+        torchvision ResNet-18 backbone is created.  Only the feature
+        extraction part is used and its parameters are frozen.
+    feat_dim: int, default=512
+        Dimension of the output feature vector for each image.
+    use_depth: bool, default=False
+        Whether an additional depth map is provided for each image.
+    """
+
+    def __init__(
+        self,
+        backbone: Optional[nn.Module] = None,
+        feat_dim: int = 512,
+        use_depth: bool = False,
+    ) -> None:
+        super().__init__()
+        if backbone is None:
+            if models is None:  # fallback minimal CNN if torchvision unavailable
+                backbone = nn.Sequential(
+                    nn.Conv2d(3, 64, kernel_size=7, stride=2, padding=3, bias=False),
+                    nn.BatchNorm2d(64),
+                    nn.ReLU(inplace=True),
+                    nn.AdaptiveAvgPool2d((1, 1)),
+                )
+                backbone.out_channels = 64
+            else:
+                base = models.resnet18(weights=models.ResNet18_Weights.IMAGENET1K_V1)
+                backbone = nn.Sequential(*list(base.children())[:-2])
+                for p in backbone.parameters():
+                    p.requires_grad = False
+                backbone.out_channels = base.fc.in_features
+        self.backbone = backbone
+        self.use_depth = use_depth
+
+        if use_depth:
+            # simple depth encoder, parameters are trainable
+            self.depth_encoder = nn.Sequential(
+                nn.Conv2d(1, 16, 3, padding=1),
+                nn.ReLU(inplace=True),
+                nn.Conv2d(16, 32, 3, padding=1),
+                nn.ReLU(inplace=True),
+                nn.AdaptiveAvgPool2d((1, 1)),
+            )
+            self.depth_fc = nn.Linear(32, feat_dim)
+
+        self.reduce_conv = nn.Conv2d(self.backbone.out_channels, feat_dim, 1)
+        self.output_fc = nn.Linear(feat_dim, feat_dim)
+
+    def forward(self, img: torch.Tensor, depth: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Encode a single image (and optional depth map) into a feature vector.
+
+        Parameters
+        ----------
+        img: torch.Tensor
+            Tensor of shape ``(B, 3, H, W)``.
+        depth: torch.Tensor, optional
+            Tensor of shape ``(B, 1, H, W)`` representing depth.
+
+        Returns
+        -------
+        feat: torch.Tensor
+            Tensor of shape ``(B, feat_dim)`` containing the distortion
+            related representation of the input image.
+        """
+
+        conv_feat = self.backbone(img)  # (B, C, h, w)
+        local_feat = self.reduce_conv(conv_feat)
+        local_feat = F.adaptive_avg_pool2d(local_feat, (1, 1)).flatten(1)
+
+        if self.use_depth and depth is not None:
+            d_feat = self.depth_encoder(depth).flatten(1)
+            d_feat = self.depth_fc(d_feat)
+            local_feat = local_feat + d_feat
+
+        feat = self.output_fc(local_feat)
+        return feat
+
+
+class MIAModule(nn.Module):
+    """Multi-view Interaction Aggregation module.
+
+    A stack of Transformer encoder layers is used to model relations
+    among features from different viewpoints.
+    """
+
+    def __init__(
+        self,
+        feat_dim: int,
+        num_views: int = 6,
+        num_layers: int = 2,
+        num_heads: int = 8,
+    ) -> None:
+        super().__init__()
+        enc_layer = nn.TransformerEncoderLayer(
+            d_model=feat_dim, nhead=num_heads, dim_feedforward=feat_dim * 2
+        )
+        self.transformer = nn.TransformerEncoder(enc_layer, num_layers)
+        self.view_pos_embedding = nn.Parameter(torch.randn(num_views, feat_dim))
+
+    def forward(self, feat_seq: torch.Tensor) -> torch.Tensor:
+        """Fuse a sequence of view features.
+
+        Parameters
+        ----------
+        feat_seq: torch.Tensor
+            Sequence tensor of shape ``(V, B, D)`` where ``V`` is the
+            number of views, ``B`` the batch size and ``D`` the feature
+            dimension.
+
+        Returns
+        -------
+        torch.Tensor
+            Fused feature of shape ``(B, D)``.
+        """
+
+        seq = feat_seq + self.view_pos_embedding.unsqueeze(1)
+        fused = self.transformer(seq)
+        fused_feat = fused.mean(dim=0)
+        return fused_feat
+
+
+class MultiViewIQAModel(nn.Module):
+    """Complete multi-view MOS prediction network."""
+
+    def __init__(
+        self,
+        dfe: DFEModule,
+        feat_dim: int = 512,
+        use_distortion_cls: bool = False,
+        num_distortion_types: int = 0,
+    ) -> None:
+        super().__init__()
+        self.dfe = dfe
+        self.mia = MIAModule(feat_dim=feat_dim, num_views=6)
+        self.score_head = nn.Sequential(
+            nn.Linear(feat_dim, feat_dim // 2),
+            nn.ReLU(inplace=True),
+            nn.Linear(feat_dim // 2, 1),
+        )
+        self.use_distortion_cls = use_distortion_cls
+        if use_distortion_cls and num_distortion_types > 0:
+            self.distortion_cls_head = nn.Linear(feat_dim, num_distortion_types)
+        else:
+            self.distortion_cls_head = None
+
+    def forward(
+        self,
+        images: Iterable[torch.Tensor],
+        depths: Optional[Iterable[torch.Tensor]] = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        feats: List[torch.Tensor] = []
+        depths = list(depths) if depths is not None else [None] * len(images)
+        for img, dep in zip(images, depths):
+            feats.append(self.dfe(img, dep).unsqueeze(0))
+        feat_seq = torch.cat(feats, dim=0)
+        fused = self.mia(feat_seq)
+        score = self.score_head(fused)
+        if self.distortion_cls_head is not None:
+            logits = self.distortion_cls_head(fused)
+            return score, logits
+        return score
+
+
+__all__ = ["DFEModule", "MIAModule", "MultiViewIQAModel"]

--- a/computer_vision/multi_view_iqa/train.py
+++ b/computer_vision/multi_view_iqa/train.py
@@ -1,0 +1,77 @@
+"""Minimal training script for the multi-view MOS prediction model.
+
+This script is intentionally lightweight and serves as an example of how
+all pieces fit together.  It does not implement distributed training or
+advanced logging but mirrors the structure described in the design
+specification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import torch
+from torch.utils.data import DataLoader
+
+from .dataset import MVSDataset
+from .model import DFEModule, MultiViewIQAModel
+from .losses import (
+    smooth_l1,
+    pairwise_rank_loss,
+    zscore_mse,
+    anchor_consistency_loss,
+    anchor_relative_loss,
+)
+
+
+@dataclass
+class Config:
+    meta_file: Path
+    use_depth: bool = False
+    batch_size: int = 4
+    lr: float = 1e-4
+    epochs: int = 1
+
+
+def build_model(cfg: Config) -> MultiViewIQAModel:
+    dfe = DFEModule(use_depth=cfg.use_depth)
+    model = MultiViewIQAModel(dfe)
+    return model
+
+
+def train(cfg: Config) -> None:
+    dataset = MVSDataset(cfg.meta_file, use_depth=cfg.use_depth)
+    loader = DataLoader(dataset, batch_size=cfg.batch_size, shuffle=True)
+    model = build_model(cfg)
+    optim = torch.optim.Adam(filter(lambda p: p.requires_grad, model.parameters()), lr=cfg.lr)
+
+    model.train()
+    for epoch in range(cfg.epochs):
+        for batch in loader:
+            images = batch["images"]
+            depths = batch.get("depths")
+            target = batch["mos"]
+            pred = model(images, depths)
+            l1 = smooth_l1(pred, target)
+            rank = pairwise_rank_loss(pred.view(-1), target.view(-1))
+            zmse = zscore_mse(pred, target)
+            ac = anchor_consistency_loss(pred, target, max_val=1.0, min_val=0.0)
+            ar = anchor_relative_loss(pred, target, max_val=1.0, min_val=0.0)
+            loss = l1 + 0.5 * rank + zmse + 0.2 * (ac + ar)
+            optim.zero_grad()
+            loss.backward()
+            optim.step()
+        print(f"epoch {epoch}: loss={loss.item():.4f}")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Train multi-view MOS model")
+    parser.add_argument("meta_file", type=Path, help="metadata file")
+    parser.add_argument("--use-depth", action="store_true")
+    args = parser.parse_args()
+    cfg = Config(meta_file=args.meta_file, use_depth=args.use_depth)
+    train(cfg)

--- a/computer_vision/multi_view_iqa/utils.py
+++ b/computer_vision/multi_view_iqa/utils.py
@@ -1,0 +1,34 @@
+"""Utility functions for evaluation and analysis."""
+
+from __future__ import annotations
+
+import math
+from typing import Tuple
+
+import torch
+
+__all__ = ["five_param_logistic", "fit_logistic"]
+
+
+def five_param_logistic(x: torch.Tensor, b1, b2, b3, b4, b5):
+    """Five parameter logistic function used in IQA evaluation."""
+    return b2 + (b1 - b2) / (1 + torch.exp((b3 - x) / torch.abs(b4))) + b5 * x
+
+
+def fit_logistic(x: torch.Tensor, y: torch.Tensor, iters: int = 2000, lr: float = 1e-3) -> Tuple[float, float, float, float, float]:
+    """Fit the parameters of the five parameter logistic using gradient descent.
+
+    The function avoids external dependencies (SciPy).  Parameters are
+    optimised to minimise mean squared error between ``five_param_logistic(x)``
+    and ``y``.
+    """
+
+    b = torch.zeros(5, requires_grad=True, dtype=x.dtype)
+    optimiser = torch.optim.Adam([b], lr=lr)
+    for _ in range(iters):
+        optimiser.zero_grad()
+        pred = five_param_logistic(x, *b)
+        loss = torch.mean((pred - y) ** 2)
+        loss.backward()
+        optimiser.step()
+    return tuple(b.detach().cpu().tolist())


### PR DESCRIPTION
## Summary
- implement distortion feature encoder (DFE), multi-view interaction aggregation (MIA) transformer and a combined IQA model for six-view stereo MOS prediction
- add dataset loader, loss functions, utilities and minimal training script
- document usage in a dedicated README

## Testing
- `python -m py_compile computer_vision/multi_view_iqa/*.py`
- `pip install torch torchvision --quiet` *(fails: ProxyError 403)*

------
https://chatgpt.com/codex/tasks/task_e_68980d0ebe28832e8ccbfa7fa4c4e25f