### PR TITLE
Add multi-view cross attention IQA model

### DIFF
--- a/computer_vision/iqa/crossscore_adapt/__init__.py
+++ b/computer_vision/iqa/crossscore_adapt/__init__.py
@@ -1,0 +1,5 @@
+from .multi_view_cross_attention import MultiViewCrossAttention
+from .backbone import ViewBackbone
+from .model import IQAModel
+
+__all__ = ["MultiViewCrossAttention", "ViewBackbone", "IQAModel"]

--- a/computer_vision/iqa/crossscore_adapt/backbone.py
+++ b/computer_vision/iqa/crossscore_adapt/backbone.py
@@ -1,0 +1,79 @@
+import torch
+from torch import nn
+
+
+class FastITPN(nn.Module):
+    """A lightweight placeholder for the Fast-iTPN backbone."""
+
+    def __init__(self, in_ch: int = 3, embed_dim: int = 64) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Conv2d(in_ch, embed_dim, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.AdaptiveAvgPool2d(1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        feat = self.net(x)
+        return feat.flatten(1)
+
+
+class VMamba(nn.Module):
+    """A lightweight placeholder for the VMamba backbone."""
+
+    def __init__(self, in_ch: int = 3, embed_dim: int = 64) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Conv2d(in_ch, embed_dim, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(embed_dim, embed_dim, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.AdaptiveAvgPool2d(1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        feat = self.net(x)
+        return feat.flatten(1)
+
+
+class ViewBackbone(nn.Module):
+    """Wrapper that adds viewpoint positional encoding and selects the backbone."""
+
+    def __init__(
+        self,
+        name: str = "fast_itpn",
+        in_ch: int = 3,
+        embed_dim: int = 64,
+        num_views: int = 4,
+    ) -> None:
+        super().__init__()
+        name = name.lower()
+        if name == "fast_itpn":
+            self.backbone = FastITPN(in_ch, embed_dim)
+        elif name == "vmamba":
+            self.backbone = VMamba(in_ch, embed_dim)
+        else:
+            raise ValueError(f"Unknown backbone: {name}")
+
+        self.pos_embed = nn.Embedding(num_views, embed_dim)
+
+    def forward(self, x: torch.Tensor, view_indices: torch.Tensor) -> torch.Tensor:
+        """Extract per-view features with positional encoding.
+
+        Args:
+            x: Tensor of shape ``(B, V, C, H, W)`` containing input images.
+            view_indices: Long tensor of shape ``(B, V)`` specifying the
+                viewpoint index of each image.
+
+        Returns:
+            Tensor of shape ``(B, V, 1, C)`` ready for cross-attention.
+        """
+
+        B, V = x.shape[:2]
+        feats = []
+        for v in range(V):
+            feat = self.backbone(x[:, v])  # (B, C)
+            feat = feat + self.pos_embed(view_indices[:, v])
+            feats.append(feat.unsqueeze(1))
+        feats = torch.cat(feats, dim=1)  # (B, V, C)
+        return feats.unsqueeze(2)

--- a/computer_vision/iqa/crossscore_adapt/model.py
+++ b/computer_vision/iqa/crossscore_adapt/model.py
@@ -1,0 +1,50 @@
+import torch
+from torch import nn
+
+from .backbone import ViewBackbone
+from .multi_view_cross_attention import MultiViewCrossAttention
+
+
+class IQAModel(nn.Module):
+    """Integrates the backbone and cross-attention for multi-view IQA."""
+
+    def __init__(
+        self,
+        backbone: str = "fast_itpn",
+        embed_dim: int = 64,
+        num_heads: int = 4,
+        num_views: int = 4,
+    ) -> None:
+        super().__init__()
+        self.backbone = ViewBackbone(
+            name=backbone, embed_dim=embed_dim, num_views=num_views
+        )
+        self.cross_attn = MultiViewCrossAttention(dim=embed_dim, num_heads=num_heads)
+        self.delta_head = nn.Linear(embed_dim, 1)
+        self.mos_head = nn.Linear(embed_dim, 1)
+
+    def forward(
+        self,
+        imgs: torch.Tensor,
+        view_indices: torch.Tensor,
+        is_ref: torch.Tensor,
+    ):
+        """Forward pass.
+
+        Args:
+            imgs: Tensor of shape ``(B, V, C, H, W)``.
+            view_indices: Tensor of shape ``(B, V)`` with viewpoint ids.
+            is_ref: Bool tensor of shape ``(B, V)`` marking reference views.
+
+        Returns:
+            A tuple ``(pred_mos, base_mos)`` where ``pred_mos`` is the final
+            MOS prediction ``(ΔMOS + MOS)`` and ``base_mos`` is the base MOS
+            estimate used during training.
+        """
+
+        feats = self.backbone(imgs, view_indices)  # (B, V, 1, C)
+        feats = self.cross_attn(feats, is_ref).squeeze(2)  # (B, V, C)
+        delta = self.delta_head(feats).squeeze(-1)
+        mos = self.mos_head(feats).squeeze(-1)
+        pred = mos + delta
+        return pred, mos

--- a/computer_vision/iqa/crossscore_adapt/multi_view_cross_attention.py
+++ b/computer_vision/iqa/crossscore_adapt/multi_view_cross_attention.py
@@ -1,0 +1,60 @@
+import torch
+from torch import nn
+
+
+class MultiViewCrossAttention(nn.Module):
+    """Cross-attention across multiple views.
+
+    Each view attends to a set of other views in order to find a relative
+    reference.  Views flagged with ``is_ref`` are treated as references while
+    the others are predicted images.  For every view ``v`` the module gathers
+    features from the opposite type (reference vs. non-reference) and performs
+    multi-head cross-attention.
+
+    Args:
+        dim: Feature dimension of the tokens.
+        num_heads: Number of attention heads.
+    """
+
+    def __init__(self, dim: int, num_heads: int = 4) -> None:
+        super().__init__()
+        self.attn = nn.MultiheadAttention(dim, num_heads, batch_first=True)
+
+    def forward(self, feats: torch.Tensor, is_ref: torch.Tensor) -> torch.Tensor:
+        """Apply cross attention.
+
+        Args:
+            feats: Tensor of shape ``(B, V, N, C)`` where ``V`` is the number of
+                views and ``N`` is the number of tokens per view.
+            is_ref: Bool tensor of shape ``(B, V)`` indicating whether the view
+                is a reference.
+
+        Returns:
+            Tensor of the same shape as ``feats`` containing the updated
+            features after cross-attention.
+        """
+
+        B, V, N, C = feats.shape
+        output = torch.zeros_like(feats)
+
+        for b in range(B):
+            for v in range(V):
+                query = feats[b, v].unsqueeze(0)  # (1, N, C)
+
+                # Select context views based on ``is_ref`` flag.
+                if is_ref[b, v]:
+                    mask = ~is_ref[b]
+                else:
+                    mask = is_ref[b]
+
+                context = feats[b, mask]
+                if context.numel() == 0:
+                    # No available context views; copy the query features.
+                    output[b, v] = feats[b, v]
+                    continue
+
+                key = context.reshape(1, -1, C)  # (1, ctx*N, C)
+                attn_out, _ = self.attn(query, key, key)
+                output[b, v] = attn_out.squeeze(0)
+
+        return output


### PR DESCRIPTION
## Summary
- add multi-view cross attention module with explicit reference flags
- implement backbone that swaps between Fast-iTPN and VMamba with viewpoint embeddings
- assemble IQA model predicting MOS adjustments and final MOS

## Testing
- `python -m py_compile computer_vision/iqa/crossscore_adapt/*.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'cv2'; SyntaxError in recall_precision_test.py)*

------
https://chatgpt.com/codex/tasks/task_e_689a334ec728832e889fca74f38c5112